### PR TITLE
Add Grok 3 models

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
           "type": "string",
           "default": "grok-2",
           "enum": [
+            "grok-3-fast",
+            "grok-3-mini-fast",
+            "grok-3-mini",
+            "grok-3",
             "grok-2-vision",
             "grok-2",
             "grok-vision-beta",


### PR DESCRIPTION
Grok 3 models can be requested using form and available in the xAPI already. Would be great to add it to VSCode configuration.

![Screenshot 2025-04-17 at 5 48 59 PM](https://github.com/user-attachments/assets/f2ba6bcf-a2f1-489d-a064-0c3772c8ae13)

Official names has `beta` at the end and has aliases. I used aliases in the `package.json` configuration for long-term support when Grok 3 is out of beta.

```
            {
                "aliases": [
                    "grok-3",
                    "grok-3-latest"
                ],
                "name": "grok-3-beta",
            },
```